### PR TITLE
Add `callout` shortcode

### DIFF
--- a/content/ff-test.md
+++ b/content/ff-test.md
@@ -14,7 +14,13 @@ This is my first (testing) blog post.
 keysmash: hjhllkhlhhjhhj
 
 
+{% callout() %}
+Test callout text blah vlah  vla}hd dhjejcjcdjcjcjejdj djdjc.
 
+Markdown **is** _supported_ [example link](https://example.com). 
+
+Some long text so you can see how it loooooks: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat...
+{% end %}
 
 Katex:
 

--- a/themes/terminimal/sass/callout.scss
+++ b/themes/terminimal/sass/callout.scss
@@ -1,0 +1,31 @@
+// Stolen from notion
+
+div.callout {
+    display: flex; 
+    width: 100%; 
+    border-radius: 3px; 
+    border-width: 1px; 
+    border-style: solid; 
+    border-color: transparent;
+    background: var(--accent-alpha-20);
+    padding: 16px 16px 16px 12px;
+}
+
+img.callout-icon {
+    width: 16px;
+    height: 16px;
+    display: flex; 
+    margin: 4px;
+}
+
+div.callout-body {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    margin-left: 8px;
+}
+
+.callout-body p {
+    margin-top: 0;
+    margin-bottom: 0;
+}

--- a/themes/terminimal/sass/style.scss
+++ b/themes/terminimal/sass/style.scss
@@ -6,3 +6,4 @@
 @import 'post';
 @import 'pagination';
 @import 'footer';
+@import 'callout'

--- a/themes/terminimal/templates/shortcodes/callout.html
+++ b/themes/terminimal/templates/shortcodes/callout.html
@@ -1,0 +1,7 @@
+<div class="callout">
+    <img class="callout-icon" src="https://raw.githubusercontent.com/twitter/twemoji/master/assets/svg/1f438.svg"
+        alt="🐸" />
+    <div class="callout-body">
+        {{ body | markdown | safe }}
+    </div>
+</div>


### PR DESCRIPTION
Usage:
```markdown
{% callout() %}
Test callout text blah vlah  vla}hd dhjejcjcdjcjcjejdj djdjc.

Markdown **is** _supported_ [example link](https://example.com). 

Some long text so you can see how it loooooks: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat...
{% end %}
```

How it looks:
![image](https://user-images.githubusercontent.com/38225716/130148435-98f1800e-ccbe-4c4b-b952-c4ef63429228.png)
